### PR TITLE
Fix versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ service in your `docker-compose.yml` as shown below.
 ```yaml
 version: '2.1'
 services:
-  home:
+  sweet-home:
     image: pipex/sweet-home:latest
     privileged: true # (optional) use this is you want to have your container have access to the host
     network_mode: host # (optional) use this to add access to the host network interfaces

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.1'
 services:
-  home:
-    image: pipex/sweet-home:latest
+  sweet-home:
+    build: ./ 
     privileged: true # (optional) use this is you want to have your container have access to the host
     network_mode: host # (optional) use this to add access to the host network interfaces
     command: sleep infinity # allows the container to run as a daemon

--- a/entry.sh
+++ b/entry.sh
@@ -27,10 +27,6 @@ fi
 nix-channel --update
 home-manager switch || echo "Failed to load home manager config. Check your home.nix"
 
-# Set version as an env var for usage in scripts
-version=$(cat /etc/sweet-home-version)
-export SWEET_HOME_VERSION="${version}"
-
 # Load home manager session vars if it exists
 . "${HOME}/.nix-profile/etc/profile.d/hm-session-vars.sh" || true
 


### PR DESCRIPTION
This fix allows the SWEET_HOME_VERSION env var to be available both in interactive
ash shell and with zsh through .zshenv. It also fixes a bug where the
published block version would be one version behind the latest due to
the docker-compose pointing to the docker image instead of the local
code.

Change-type: patch