### PR TITLE
Do not load hmvars if not present

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN rm -rf /usr/local
 # Copy nix dependencies
 COPY --from=nix --chown=${UID} /output/store /nix/store
 COPY --from=nix /output/profile/ /usr/local/
+COPY --from=nix /env.sh /etc/zshenv
 
 # Install minimal tools and create user
 RUN apk --update add --no-cache sudo tini iputils git tzdata procps && \
@@ -40,8 +41,8 @@ USER ${UID}
 ENV USER ${USER}
 ENV HOME /home/${USER}
 
-# Also add version to ashrc
-COPY --from=nix --chown=${UID} /env.sh /home/${USER}/.zshenv
+# Add environment variables for ashrc
+COPY --from=nix --chown=${UID} /env.sh /home/${USER}/.env
 
 # These variables are usually set from /etc/profile but
 # we want them there for all shells
@@ -55,9 +56,7 @@ ENV NIX_PROFILES="/nix/var/nix/profiles/default $HOME/.nix-profile"
 ENV NIX_SSL_CERT_FILE="/etc/ssl/certs/ca-certificates.crt"
 ENV MANPATH="$HOME/.nix-profile/share/man:$MANPATH"
 ENV PATH="$HOME/.nix-profile/bin:$PATH"
-
-# Cover both ash and zsh
-ENV ENV="/home/${USER}/.zshenv" 
+ENV ENV="/home/${USER}/.env" 
 
 # Add nixpath channel but don't update it yet.
 # The update and install of default packages will happen on

--- a/entry.sh
+++ b/entry.sh
@@ -25,9 +25,9 @@ fi
 
 # Update channel definitions and install extra dependencies
 nix-channel --update
-home-manager switch || echo "Failed to load home manager config. Check your home.nix"
+home-manager switch || echo "Failed to load home manager config. Check your home.nix" >&2
 
 # Load home manager session vars if it exists
-. "${HOME}/.nix-profile/etc/profile.d/hm-session-vars.sh" || true
+[ -f "${HOME}/.nix-profile/etc/profile.d/hm-session-vars.sh" ] && . "${HOME}/.nix-profile/etc/profile.d/hm-session-vars.sh"
 
 exec ${cmd}


### PR DESCRIPTION
This prevents errors during home manager setup to cause the entry script to fail. It also moves ~/.zshenv to /etc/zshenv to avoid conflicts with newer zsh installs.

Change-type: patch