### PR TITLE
Move hmvars load to bash stub

### DIFF
--- a/bash.stub
+++ b/bash.stub
@@ -1,8 +1,11 @@
 #!/bin/sh
 
+# Load home manager session vars if it exists
+[ -f "${HOME}/.nix-profile/etc/profile.d/hm-session-vars.sh" ] && . "${HOME}/.nix-profile/etc/profile.d/hm-session-vars.sh"
+
 # User preferred shell. Can be configured in home manager using
 # home.sessionVars
 SWEET_HOME_SHELL=${SWEET_HOME_SHELL:-"sh"}
 
 # Run with user chosen shell
-"${SWEET_HOME_SHELL}" "$@"
+PATH=${HOME}/.nix-profile/bin:${PATH} "${SWEET_HOME_SHELL}" "$@"

--- a/entry.sh
+++ b/entry.sh
@@ -27,7 +27,4 @@ fi
 nix-channel --update
 home-manager switch || echo "Failed to load home manager config. Check your home.nix" >&2
 
-# Load home manager session vars if it exists
-[ -f "${HOME}/.nix-profile/etc/profile.d/hm-session-vars.sh" ] && . "${HOME}/.nix-profile/etc/profile.d/hm-session-vars.sh"
-
 exec ${cmd}


### PR DESCRIPTION
This allows the personalized shell to be loaded by the dashboard terminal as well.

Change-type: patch